### PR TITLE
Allow name of pick executable to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For example, you could implement `PickFile()` like this:
 call PickCommand("find * -type f", "", ":edit")
 ```
 
-### Mapping keys
+### Configuration
 
 Add your preferred key mappings to your `.vimrc` file:
 
@@ -65,6 +65,12 @@ map <Leader>s :call PickFileSplit()<CR>
 map <Leader>v :call PickFileVerticalSplit()<CR>
 map <Leader>t :call PickFileTab()<CR>
 map <Leader>b :call PickBuffer()<CR>
+```
+
+The name of the pick executable can be configured with:
+
+```viml
+let g:pick_executable = "pick"
 ```
 
 ## Copyright

--- a/plugin/pick.vim
+++ b/plugin/pick.vim
@@ -1,6 +1,10 @@
+if !exists("g:pick_executable")
+  let g:pick_executable = "pick"
+endif
+
 function! PickCommand(choice_command, pick_args, vim_command)
   try
-    let selection = system(a:choice_command . " | pick" . a:pick_args)
+    let selection = system(a:choice_command . " | " . g:pick_executable . " " . a:pick_args)
     redraw!
     if v:shell_error == 0
       try


### PR DESCRIPTION
This change allows the user to configure which fuzzy selector to use.  The motivating use case is that I've been trying out pick and selecta as replacements for ctrlp.vim, and this lets me swap between the two by setting `g:pick_executable` without having to edit pick.vim's source every time.
