### PR TITLE
Escape file names with spaces or special characters

### DIFF
--- a/plugin/pick.vim
+++ b/plugin/pick.vim
@@ -8,11 +8,11 @@ endif
 
 function! PickCommand(choice_command, pick_args, vim_command)
   try
-    let selection = system(a:choice_command . " | " . g:pick_executable . " " . a:pick_args)
+    let selection = systemlist(a:choice_command . " | " . g:pick_executable . " " . a:pick_args)[0]
     redraw!
     if v:shell_error == 0
       try
-        exec a:vim_command . " " . selection
+        exec a:vim_command . " " . fnameescape(selection)
       catch /E325/
       endtry
     endif


### PR DESCRIPTION
Uses `systemlist()` instead of `system()` to automatically remove newlines from the selection, then uses `fnameescape()` to escape the selection as a file name.

When researching how to properly strip newlines, I used this for reference: http://vi.stackexchange.com/questions/2867/how-do-you-chomp-a-string-in-vim. The accepted answer highlights a potential portability problem with `systemlist()`, which won't strip `\r` from its input. However, because I know that `pick(1)` [only uses `\n` for newlines](https://github.com/thoughtbot/pick/blob/ebf87b4b2a02a3f080534ee256846b33b28762bb/src/pick.c#L174), I though that `systemlist()` is probably sufficient, and simpler than using `substite()`.
