### PR TITLE
Fallback to system if systemlist doesn't exist

### DIFF
--- a/plugin/pick.vim
+++ b/plugin/pick.vim
@@ -8,7 +8,12 @@ endif
 
 function! PickCommand(choice_command, pick_args, vim_command)
   try
-    let selection = systemlist(a:choice_command . " | " . g:pick_executable . " " . a:pick_args)[0]
+    let pick_command = a:choice_command . " | " . g:pick_executable . " " . a:pick_args
+    if exists("*systemlist")
+      let selection = systemlist(pick_command)[0]
+    else
+      let selection = substitute(system(pick_command), '\n$', '', '')
+    endif
     redraw!
     if v:shell_error == 0
       try


### PR DESCRIPTION
`systemlist` was introduced in [7.4.248](https://github.com/vim/vim/commit/39c29ed5118ab513554d1d51d6a98e65f32784ba) (and was buggy until
[7.4.256](https://github.com/vim/vim/commit/b21a29be56fb0e125d9f736bfdef8dde5a1ceae0)), which precludes using pick.vim with the versions of Vim
shipped with OS X 10.11 and Ubuntu 14.04.

Using `system` with `fnameescape` requires manually stripping the
trailing newline.
