### PR TITLE
Update repo references and sponsorship status

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+<pick-maintainers@calleerlandsson.com>. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version].
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 We love pull requests from everyone. By participating in this project, you agree
-to abide by the thoughtbot [code of conduct].
+to abide by its [code of conduct].
 
-[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+[code of conduct]: https://github.com/calleerlandsson/pick.vim/blob/master/CODE_OF_CONDUCT.md
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Functions for using [pick] from within Vim.
 ***Please note:*** pick requires a fully functional terminal to run therefore
 cannot be run from within gvim or MacVim.
 
-[pick]: https://github.com/thoughtbot/pick/
+[pick]: https://github.com/calleerlandsson/pick/
 
 ## Installation
 
 Recommended installation with [Vundle]:
 
 ```viml
-Plugin 'thoughtbot/pick.vim'
+Plugin 'calleerlandsson/pick.vim'
 ```
 
 [Vundle]: https://github.com/gmarik/Vundle.vim/
@@ -86,6 +86,4 @@ let g:pick_height = 10
 
 ## Copyright
 
-Copyright (c) 2014 Calle Erlandsson & thoughtbot, Inc.
-
-Lead by Calle Erlandsson & thoughtbot, Inc.
+Copyright (c) 2016 Calle Erlandsson, Teo Ljungberg & thoughtbot.


### PR DESCRIPTION
The pick and pick.vim GitHub repos were transferred from the thoughtbot
organization to calleerlandsson and thoughtbot is no longer sponsoring
the project.

Changes:
- Update and include the project's code of conduct.
- Add "Teo Ljungberg" to the README as a maintainer.